### PR TITLE
Resolve `libs-release-local` and avoid annoying enablePlugin

### DIFF
--- a/src/main/scala/com/adevinta/unicron/artifactory/ArtifactorySettingsPlugin.scala
+++ b/src/main/scala/com/adevinta/unicron/artifactory/ArtifactorySettingsPlugin.scala
@@ -24,6 +24,8 @@ object ArtifactorySettingsPlugin extends AutoPlugin {
 
   val autoImport: ArtifactoryKeys.type = ArtifactoryKeys
 
+  override def trigger = allRequirements
+
   override def buildSettings: Seq[Setting[_]] = Seq(
     artifactoryContextEnv := "ARTIFACTORY_CONTEXT",
     artifactoryUserEnv := "ARTIFACTORY_USER",
@@ -77,6 +79,7 @@ object ArtifactorySettingsPlugin extends AutoPlugin {
       Seq(
         if (isSnapshot.value) Some(Resolver.mavenLocal) else None,
         Some("Artifactory Release Libs" at artifactoryJvmReleasesResolver.value),
+        Some("Artifactory Release Libs Local" at artifactoryJvmReleasesPublishResolver.value),
         if (isSnapshot.value) Some("Artifactory Snapshot Libs" at artifactoryJvmSnapshotsResolver.value) else None
       ).flatten
     },


### PR DESCRIPTION
By overriding `trigger` to `allRequirements` it is no longer needed to put a `enablePlugins(ArtifactorySettingsPlugin)` on each and every project (simply putting it in the plugins.sbt is enough).

We add the `libs-release-local` artifactory repository to the resolvers because even though we publish to it by default, we do not resolved from it, meaning that we can't get the libraries that we just published.